### PR TITLE
Update client to use axios.post

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
     "@types/node": "^13.7.0",
     "jest": "~25.1.0",
     "prettier": "1.19.1",
+    "ts-jest": "^25.2.0",
     "tslint": "^5.11.0",
     "tslint-config-prettier": "1.18.0",
-    "typescript": "^3.1.1",
-    "ts-jest": "^25.2.0"
+    "typescript": "^3.1.1"
   },
   "scripts": {
     "build": "tsc ",
@@ -31,6 +31,6 @@
     "postversion": "git push && git push --tags"
   },
   "dependencies": {
-   
+    "axios": "^0.19.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cql-translation-service-client",
-  "version": "0.1.1",
+  "version": "0.5.0",
   "description": "A client for the cql-translation-service",
   "repository": "https://github.com/mcode/cql-translation-service-client",
   "license": "Apache 2.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "postversion": "git push && git push --tags"
   },
   "dependencies": {
-    "axios": "^0.19.2"
+    "axios": "^0.19.2",
+    "form-data": "3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cql-translation-service-client",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A client for the cql-translation-service",
   "repository": "https://github.com/mcode/cql-translation-service-client",
   "license": "Apache 2.0",

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -22,7 +22,7 @@ const testCqlObject = {
 };
 
 const testResponse = `--Boundary_1
-Content-Type: application/elm+json
+content-type: application/elm+json
 Content-Disposition: form-data; name="main"
 
 {
@@ -38,7 +38,7 @@ Content-Disposition: form-data; name="main"
    }
 }
 --Boundary_1
-Content-Type: application/elm+json
+content-type: application/elm+json
 Content-Disposition: form-data; name="ex1"
 
 {
@@ -73,13 +73,13 @@ describe("cql-to-elm", () => {
   it("converts complex cql to elm", done => {
     (axios.post as jest.Mock).mockImplementation(() =>
       Promise.resolve({
-        headers: {
-          get: (s: string): string => testHeader
-        },
-        text: () => Promise.resolve(testResponse)
+        headers: {"content-type": testHeader},
+        data: testResponse
       })
     );
     client.convertCQL(testCqlObject).then(elms => {
+      console.log(elms);
+      
       expect(elms).toHaveProperty("main");
       expect(elms).toHaveProperty("main.library");
       expect(elms).toHaveProperty("main.library.identifier");

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -1,12 +1,15 @@
-import {Client} from '../client'; 
-const globalAny:any = global;
-const client = new Client('');
+import axios from "axios";
+import { Client } from "../client";
+
+jest.mock("axios");
+
+const client = new Client("");
 const testCQL = "library mCODEResources version '1'";
 const testELM = {
   library: {
     identifier: {
-      id: 'mCODEResources',
-      version: '1'
+      id: "mCODEResources",
+      version: "1"
     }
   }
 };
@@ -52,21 +55,23 @@ Content-Disposition: form-data; name="ex1"
 }
 --Boundary_1--`;
 
-const testHeader = 'multipart/form-data;boundary=Boundary_1';
-describe('cql-to-elm', () => {
-  it('converts basic cql to elm', done => {
-    globalAny.fetch = jest.fn(() => Promise.resolve({ json: () => testELM }));
+const testHeader = "multipart/form-data;boundary=Boundary_1";
+describe("cql-to-elm", () => {
+  it("converts basic cql to elm", done => {
+    (axios.post as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: testELM })
+    );
     client.convertBasicCQL(testCQL).then(elm => {
-      expect(elm).toHaveProperty('library');
-      expect(elm).toHaveProperty('library.identifier');
-      expect(elm).toHaveProperty('library.identifier.id', 'mCODEResources');
-      expect(elm).toHaveProperty('library.identifier.version', '1');
+      expect(elm).toHaveProperty("library");
+      expect(elm).toHaveProperty("library.identifier");
+      expect(elm).toHaveProperty("library.identifier.id", "mCODEResources");
+      expect(elm).toHaveProperty("library.identifier.version", "1");
       done();
     });
   });
 
-  it('converts complex cql to elm', done => {
-    globalAny.fetch = jest.fn(() =>
+  it("converts complex cql to elm", done => {
+    (axios.post as jest.Mock).mockImplementation(() =>
       Promise.resolve({
         headers: {
           get: (s: string): string => testHeader
@@ -74,17 +79,23 @@ describe('cql-to-elm', () => {
         text: () => Promise.resolve(testResponse)
       })
     );
-   client.convertCQL(testCqlObject).then(elms => {
-      expect(elms).toHaveProperty('main');
-      expect(elms).toHaveProperty('main.library');
-      expect(elms).toHaveProperty('main.library.identifier');
-      expect(elms).toHaveProperty('main.library.identifier.id', 'mCODEResources');
+    client.convertCQL(testCqlObject).then(elms => {
+      expect(elms).toHaveProperty("main");
+      expect(elms).toHaveProperty("main.library");
+      expect(elms).toHaveProperty("main.library.identifier");
+      expect(elms).toHaveProperty(
+        "main.library.identifier.id",
+        "mCODEResources"
+      );
 
-      expect(elms).toHaveProperty('libraries');
-      expect(elms).toHaveProperty('libraries.ex1');
-      expect(elms).toHaveProperty('libraries.ex1.library');
-      expect(elms).toHaveProperty('libraries.ex1.library.identifier');
-      expect(elms).toHaveProperty('libraries.ex1.library.identifier.id', 'example');
+      expect(elms).toHaveProperty("libraries");
+      expect(elms).toHaveProperty("libraries.ex1");
+      expect(elms).toHaveProperty("libraries.ex1.library");
+      expect(elms).toHaveProperty("libraries.ex1.library.identifier");
+      expect(elms).toHaveProperty(
+        "libraries.ex1.library.identifier.id",
+        "example"
+      );
       done();
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -580,6 +580,13 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.9.1.tgz#7e33d8f7d449b3f673cd72deb9abdc552dbe528e"
   integrity sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==
 
+axios@^0.19.2:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
+  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+  dependencies:
+    follow-redirects "1.5.10"
+
 babel-jest@^25.1.0:
   version "25.1.0"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-25.1.0.tgz#206093ac380a4b78c4404a05b3277391278f80fb"
@@ -929,6 +936,13 @@ data-urls@^1.1.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
+debug@=3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
+
 debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -1013,11 +1027,6 @@ domexception@^1.0.1:
   integrity sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==
   dependencies:
     webidl-conversions "^4.0.2"
-
-dotenv@8.2.0:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
-  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
 
 ecc-jsbn@~0.1.1:
   version "0.1.2"
@@ -1251,6 +1260,13 @@ find-up@^4.0.0, find-up@^4.1.0:
   dependencies:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
+
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
 
 for-in@^1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -844,7 +844,7 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-combined-stream@^1.0.6, combined-stream@~1.0.6:
+combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -1277,6 +1277,15 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
+
+form-data@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.0.tgz#31b7e39c85f1355b7139ee0c647cf0de7f83c682"
+  integrity sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 form-data@~2.3.2:
   version "2.3.3"


### PR DESCRIPTION
The client currently uses fetch to call the translation service. Update to use axios.post so it can run in the browser as well as the command line. Updated tests to mock axios.post. 

Both tests pass and no lint