### PR TITLE
Update Client

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cql-translation-service-client",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A client for the cql-translation-service",
   "repository": "https://github.com/mcode/cql-translation-service-client",
   "license": "Apache 2.0",

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -14,16 +14,14 @@ const testELM = {
   }
 };
 
-const testCqlObject = {
-  main: "library mCODEResources version '1'",
-  libraries: {
-    ex1: "library example version '2'"
-  }
+const testCqlLibraries = {
+  ex1: { cql: "library mCODEResources version '1'" },
+  ex2: { cql: "library example version '2'" }
 };
 
 const testResponse = `--Boundary_1
 content-type: application/elm+json
-Content-Disposition: form-data; name="main"
+Content-Disposition: form-data; name="ex1"
 
 {
    "library" : {
@@ -39,7 +37,7 @@ Content-Disposition: form-data; name="main"
 }
 --Boundary_1
 content-type: application/elm+json
-Content-Disposition: form-data; name="ex1"
+Content-Disposition: form-data; name="ex2"
 
 {
    "library" : {
@@ -77,23 +75,23 @@ describe("cql-to-elm", () => {
         data: testResponse
       })
     );
-    client.convertCQL(testCqlObject).then(elms => {
+    client.convertCQL(testCqlLibraries).then(elms => {
       console.log(elms);
       
-      expect(elms).toHaveProperty("main");
-      expect(elms).toHaveProperty("main.library");
-      expect(elms).toHaveProperty("main.library.identifier");
+      expect(elms).toHaveProperty("ex1");
+      expect(elms).toHaveProperty("ex1.library");
+      expect(elms).toHaveProperty("ex1.library.identifier");
       expect(elms).toHaveProperty(
-        "main.library.identifier.id",
+        "ex1.library.identifier.id",
         "mCODEResources"
       );
 
-      expect(elms).toHaveProperty("libraries");
-      expect(elms).toHaveProperty("libraries.ex1");
-      expect(elms).toHaveProperty("libraries.ex1.library");
-      expect(elms).toHaveProperty("libraries.ex1.library.identifier");
+      expect(elms).toHaveProperty("ex2");
+      expect(elms).toHaveProperty("ex2");
+      expect(elms).toHaveProperty("ex2.library");
+      expect(elms).toHaveProperty("ex2.library.identifier");
       expect(elms).toHaveProperty(
-        "libraries.ex1.library.identifier.id",
+        "ex2.library.identifier.id",
         "example"
       );
       done();

--- a/src/client.ts
+++ b/src/client.ts
@@ -137,8 +137,12 @@ export class Client {
       }
     });
 
+    // Use formdata.getHeaders() in node environment, formdata.getHeaders does not work in browser
+    let headers;
+    if (formdata.getHeaders) headers = formdata.getHeaders();
+
     return axios
-      .post(this.url, formdata, {headers:  formdata.getHeaders()})
+      .post(this.url, formdata, { headers })
       .then(elm => this.handleElm(elm))
       .catch(error => {
         if (error.response?.status === 400 && error.response?.data.library)

--- a/src/client.ts
+++ b/src/client.ts
@@ -14,7 +14,7 @@ const extractCQLInclude = /include .* called (.*)/g;
 
 export interface CqlLibraries {
   [name: string]: {
-    cql?: string;
+    cql: string;
     version?: string;
   };
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,5 @@
     "types": ["node", "jest"],
   },
   "include": ["src"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "src/__tests__"]
 }


### PR DESCRIPTION
I pulled over the updates made in the pathway-builder.

- Added cql and elm types
- Removed the concept of having a "main" library. The `convertCQL` function just takes in a list of CQL libraries and converts to elm.
- Updated tests to reflect the changes.